### PR TITLE
Fix installers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,11 @@ function make_symlink {
   for f in "${target_files[@]}"; do
     from="$from_dir/$f"
     to="$to_dir/$f"
+
+    if [ ! -f "$from" ] ; then
+      continue
+    fi
+
     if [ -h "$to" ] ; then
       rm -f "$to"
     elif [ -e "$to" ] ; then

--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-SCRIPT_DIR=$(dirname $0)/scripts
+abs_base_dir=$(cd $(dirname $0); pwd)
+BASE_DIR=${abs_base_dir#$HOME/}
+SCRIPT_DIR="$BASE_DIR/scripts"
 
 function make_symlink {
   local target_files=(.bashrc .gitconfig .gitignore_global .tmux.conf .vimrc .zshrc)
-  local from_dir="$(dirname $0)"
+  local from_dir="$BASE_DIR"
   local to_dir="$HOME"
 
   for f in "${target_files[@]}"; do

--- a/scripts/setup_anyenv.sh
+++ b/scripts/setup_anyenv.sh
@@ -10,4 +10,6 @@ function setup_anyenv {
   $ANYENV_ROOT/bin/anyenv install --init
 }
 
-setup_anyenv
+if [ ! -d "$ANYENV_ROOT" ] ; then
+  setup_anyenv
+fi


### PR DESCRIPTION
Bugfix:
* `setup_anyenv.sh` failed when `$HOME/.anyenv` already exists or anyenv is already installed
* Made invalid symbolic links when running install.sh not in home directory
* No file existence checker